### PR TITLE
Kernel allowing for i.i.d. sampling from the prior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ build-backend = "hatchling.build"
 dev = [
     "black>=25.1.0",
     "jupytext>=1.17.0",
+    "numpy>=2.2.4",
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "ruff>=0.11.4",

--- a/src/pt_jax/kernels.py
+++ b/src/pt_jax/kernels.py
@@ -3,6 +3,33 @@ import jax.numpy as jnp
 import jax.random as jrandom
 
 
+def generate_sample_from_prior_kernel(
+    log_prob,
+    log_ref,
+    kernel_ref,
+    truncated_annealing_schedule,
+    kernel_generator,
+    truncated_params,
+):
+    kernel_other = generate_independent_annealed_kernel(
+        log_prob=log_prob,
+        log_ref=log_ref,
+        kernel_generator=kernel_generator,
+        params=truncated_params,
+        annealing_schedule=truncated_annealing_schedule,
+    )
+
+    def kernel(key, x):
+        x0 = x[0, ...]
+        xother = x[1:, ...]
+        key1, key2 = jax.random.split(key)
+        x0_ = kernel_ref(key1, x0)
+        xother_ = kernel_other(key2, xother)
+        return jnp.concatenate([jnp.expand_dims(x0_, 0), xother_], axis=0)
+
+    return kernel
+
+
 def generate_independent_annealed_kernel(
     log_prob,
     log_ref,

--- a/src/pt_jax/kernels.py
+++ b/src/pt_jax/kernels.py
@@ -20,11 +20,10 @@ def generate_sample_from_prior_kernel(
     )
 
     def kernel(key, x):
-        x0 = x[0, ...]
-        xother = x[1:, ...]
+        x0, x_other = x[0], x[1:]
         key1, key2 = jax.random.split(key)
         x0_ = kernel_ref(key1, x0)
-        xother_ = kernel_other(key2, xother)
+        xother_ = kernel_other(key2, x_other)
         return jnp.concatenate([jnp.expand_dims(x0_, 0), xother_], axis=0)
 
     return kernel

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,0 +1,41 @@
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+
+import pytest
+import pt_jax.kernels as K
+
+
+@pytest.mark.parametrize("n_chains", [3, 5])
+@pytest.mark.parametrize("shape", [(3,)])
+def test_smoke_generate_sample_from_prior_kernel(n_chains: int, shape: tuple):
+    def log_p(x):
+        return -1.0
+
+    def kernel_generator(log_p, param):
+        def k(key, x):
+            return x * param
+
+        return k
+
+    params = jnp.linspace(-1, 5, n_chains)
+    temperature = jnp.linspace(0, 1, n_chains)
+
+    kernel_ref = kernel_generator(log_p, 1.0)
+
+    kernel = K.generate_sample_from_prior_kernel(
+        log_prob=log_p,
+        log_ref=log_p,
+        kernel_ref=kernel_ref,
+        kernel_generator=kernel_generator,
+        truncated_annealing_schedule=temperature[1:],
+        truncated_params=params[1:],
+    )
+
+    x0 = jnp.ones([n_chains] + list(shape))
+    key = jax.random.PRNGKey(42)
+    x1 = kernel(key, x0)
+
+    assert x1.shape == x0.shape
+    # Only works for deterministic kernels
+    npt.assert_allclose(x1[0, ...], kernel_ref(key, x0[0, ...]))


### PR DESCRIPTION
Often we are able to get i.i.d. samples from the reference distribution, so we may prefer to do this, rather than employing a generic MCMC kernel.

For example, if we use the prior as the reference and the prior is multimodal (e.g., a spike-and-slab distribution), we may prefer to do ancestral sampling, rather than HMC over this distribution.