### PR TITLE
Integration with NumPyro models

### DIFF
--- a/examples/example_numpyro.py
+++ b/examples/example_numpyro.py
@@ -1,0 +1,108 @@
+"""Example of using the integration with NumPyro models."""
+
+import jax
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as dist
+import blackjax
+
+import pt_jax
+import pt_jax.numpyro as pt_jax_numpyro
+
+
+def generate_model(data=None, posterior=True):
+    def model():
+        mu = numpyro.sample("mu", dist.Normal(0.0, 10.0))
+        sigma = numpyro.sample("sigma", dist.Exponential(1 / 5.0))
+
+        # u = numpyro.deterministic("u", mu / sigma)
+
+        if posterior:
+            with numpyro.plate("data_plate", len(data)):
+                numpyro.sample("data", dist.Normal(mu, sigma), obs=data)
+
+    return model
+
+
+def mala_kernel_generator(log_p, step_size):
+    """Wrapper around the MALA kernel from BlackJAX."""
+    mala = blackjax.mala(log_p, step_size)
+
+    def kernel(key, position):
+        state = mala.init(position)
+        new_state, info = mala.step(key, state)
+        return new_state.position
+
+    return kernel
+
+
+def sampling_fn(key, wrapped, betas, x0, n_samples: int = 10_000, warmup: int = 1000):
+    # We know how to sample from the reference distribution
+    n_chains = len(betas)
+    step_sizes = jnp.linspace(0.5, 0.01, n_chains)
+
+    log_target = wrapped.log_posterior_z
+    log_ref = wrapped.log_prior_z
+
+    K_ind = pt_jax.kernels.generate_sample_from_prior_kernel(
+        log_prob=log_target,
+        log_ref=log_ref,
+        kernel_ref=wrapped.sample_prior_z,
+        truncated_annealing_schedule=betas[1:],
+        kernel_generator=mala_kernel_generator,
+        truncated_params=step_sizes[1:],
+    )
+    K_deo = pt_jax.deo.generate_deo_extended_kernel(
+        log_prob=log_target,
+        log_ref=log_ref,
+        annealing_schedule=betas,
+    )
+
+    key, subkey = jax.random.split(key)
+    samples, _ = pt_jax.deo.deo_sampling_loop(
+        key=subkey,
+        x0=jnp.zeros([n_chains] + list(x0.shape)),
+        kernel_local=K_ind,
+        kernel_deo=K_deo,
+        n_samples=n_samples,
+        warmup=warmup,
+    )
+    return samples
+
+
+def main():
+    key = jax.random.PRNGKey(101)
+    key, subkey = jax.random.split(key)
+    data = 3.0 + 2.0 * jax.random.normal(subkey, shape=(80,))
+
+    posterior_model = generate_model(data, posterior=True)
+    prior_model = generate_model(posterior=False)
+
+    wrapped = pt_jax_numpyro.wrap_models(prior_model, posterior_model)
+
+    key, subkey = jax.random.split(key)
+    init_z = wrapped.sample_prior_z(subkey)
+
+    key, subkey = jax.random.split(key)
+    n_chains = 20
+    betas = pt_jax.annealing.annealing_exponential(n_chains)
+    # Sample in the Z space (unconstrained vectors)
+    samples_z = sampling_fn(subkey, wrapped, betas, init_z)
+    # Move back to the X space (constrained dictionaries)
+
+    samples_x_prior = jax.vmap(wrapped.z_to_x)(samples_z[:, 0, ...])
+    samples_x_posterior = jax.vmap(wrapped.z_to_x)(samples_z[:, -1, ...])
+
+    for k in samples_x_prior.keys():
+        print(f"--- Parameter {k} ---")
+        mean = samples_x_prior[k].mean()
+        std = samples_x_prior[k].std()
+        print(f"  Prior:     {float(mean):.2f} +- {float(std):.2f}")
+
+        mean = samples_x_posterior[k].mean()
+        std = samples_x_posterior[k].std()
+        print(f"  Posterior: {float(mean):.2f} +- {float(std):.2f}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pt_jax/numpyro.py
+++ b/src/pt_jax/numpyro.py
@@ -1,0 +1,152 @@
+"""Utilities for making NumPyro models
+suitable for parallel tempering sampling.
+
+The most important constraints are:
+
+  - No `numpyro.deterministic` sites are allowed.
+  - Only sample the variables from prior in the prior model.
+"""
+import jax
+from numpyro.infer import Predictive
+from numpyro.infer.util import get_transforms, transform_fn, log_density
+
+from typing import Any, NamedTuple
+
+
+def _get_prior_sampling_fn(prior_model):
+    predictive = Predictive(prior_model, num_samples=1)
+
+    def fn(rng_key, *args, **kwargs):
+        prior_samples = predictive(rng_key)
+        return jax.tree.map(lambda x: x[0], prior_samples)
+
+    return fn
+
+
+def get_logprob(model):
+    def fn(params):
+        lp, _ = log_density(model, (), {}, params)
+        return lp
+
+    return fn
+
+
+class Transforms(NamedTuple):
+    x_to_u: Any
+    u_to_x: Any
+
+    z_to_u: Any
+    u_to_z: Any
+
+    x_to_z: Any
+    z_to_x: Any
+
+    transforms: Any
+
+
+def wrap_transforms(transforms: dict, example_params: dict) -> Transforms:
+    """Transforms: transform u -> x."""
+
+    def u_to_x(u):
+        return transform_fn(transforms, u, invert=False)
+
+    def x_to_u(x):
+        return transform_fn(transforms, x, invert=True)
+
+    _, z_to_u = jax.flatten_util.ravel_pytree(x_to_u(example_params))
+
+    def u_to_z(u):
+        z, _ = jax.flatten_util.ravel_pytree(u)
+        return z
+
+    def x_to_z(x):
+        u = x_to_u(x)
+        return u_to_z(u)
+
+    def z_to_x(z):
+        u = z_to_u(z)
+        return u_to_x(u)
+
+    return Transforms(
+        x_to_u=x_to_u,
+        u_to_x=u_to_x,
+        u_to_z=u_to_z,
+        z_to_u=z_to_u,
+        z_to_x=z_to_x,
+        x_to_z=x_to_z,
+        transforms=transforms,
+    )
+
+
+def get_model_transforms(model):
+    example_params = _get_prior_sampling_fn(model)(jax.random.PRNGKey(0))
+    unconstrain_transforms = get_transforms(
+        model, model_args=(), model_kwargs={}, params=example_params
+    )
+    return wrap_transforms(unconstrain_transforms, example_params=example_params)
+
+
+class LogDensities(NamedTuple):
+    logp_x: Any
+    logp_u: Any
+    logp_z: Any
+
+
+def reparameterize_logdensity(logp_x_fn, transforms: Transforms) -> LogDensities:
+    def logp_u(u):
+        # Evaluate the x coordinate and the logprob there
+        x = transforms.u_to_x(u)
+        logpx = logp_x_fn(x)
+
+        # Correct it by the log-Jacobian of the transformation
+        correction = sum(
+            [
+                transform.log_abs_det_jacobian(u[key], x[key]).sum()
+                for key, transform in transforms.transforms.items()
+            ]
+        )
+        return logpx + correction
+
+    def logp_z(z):
+        # This transformation is volume-preserving,
+        # so no Jacobian correction is required
+        return logp_u(transforms.z_to_u(z))
+
+    return LogDensities(
+        logp_x=logp_x_fn,
+        logp_u=logp_u,
+        logp_z=logp_z,
+    )
+
+
+class ParallelTemperingSetting(NamedTuple):
+    log_prior_z: Any
+    log_posterior_z: Any
+    sample_prior_z: Any
+
+
+def wrap_models(
+    prior,
+    posterior,
+) -> ParallelTemperingSetting:
+    sample_x_fn = _get_prior_sampling_fn(prior)
+    transforms = get_model_transforms(prior)
+
+    def sample_z_fn(key, *args, **kwargs):
+        x = sample_x_fn(key)
+        return transforms.x_to_z(x)
+
+    log_prior = reparameterize_logdensity(
+        get_logprob(prior),
+        transforms=transforms,
+    )
+    log_posterior = reparameterize_logdensity(
+        get_logprob(posterior),
+        transforms=transforms,
+    )
+
+    return ParallelTemperingSetting(
+        log_posterior_z=log_posterior.logp_z,
+        log_prior_z=log_prior.logp_z,
+        sample_prior_z=sample_z_fn,
+    )

--- a/src/pt_jax/numpyro.py
+++ b/src/pt_jax/numpyro.py
@@ -124,6 +124,8 @@ class ParallelTemperingSetting(NamedTuple):
     log_posterior_z: Any
     sample_prior_z: Any
 
+    z_to_x: Any
+
 
 def wrap_models(
     prior,
@@ -149,4 +151,5 @@ def wrap_models(
         log_posterior_z=log_posterior.logp_z,
         log_prior_z=log_prior.logp_z,
         sample_prior_z=sample_z_fn,
+        z_to_x=transforms.z_to_x,
     )


### PR DESCRIPTION
This PR adds a basic integration capabilities with models defined using the NumPyro probabilistic language. The idea is to define *two* models on the same space: one with the prior distribution and one with the posterior distribution. The prior model can then be used as a reference (and one obtain i.i.d. samples from it using ancestral sampling in NumPyro).

Most of the code is spent on wrapping the models to map them between the spaces: the NumPyro models are defined in terms of dictionaries (on possibly constrained spaces, e.g., some parameters can be only positive), while `pt-jax` supports unconstrained vectors only.

There are several limitations of these wrappers:

1. Discrete variables need to be marginalized out explicitly. (The sampling sites should be continuous.)
2. The `numpyro.deterministic` is *not supported*.